### PR TITLE
Add example registry and loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ dependencies = [
  "rhai",
  "serde",
  "serde_json",
+ "toml",
 ]
 
 [[package]]
@@ -2734,6 +2735,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3043,10 +3053,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -3055,9 +3080,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ egui = "0.32.1"
 eframe = "0.32.1"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.142"
+toml = "0.8.19"
 
 [dev-dependencies]
 criterion = "0.7.0"

--- a/examples/hello.md
+++ b/examples/hello.md
@@ -1,0 +1,5 @@
+# Hello World
+
+This example demonstrates running a simple Rhai script.
+
+Note: Prints a friendly greeting.

--- a/examples/hello.rhai
+++ b/examples/hello.rhai
@@ -1,0 +1,1 @@
+"hello from rhai"

--- a/examples/manifest.toml
+++ b/examples/manifest.toml
@@ -1,0 +1,5 @@
+[[examples]]
+id = "hello"
+name = "Hello World"
+script = "examples/hello.rhai"
+doc = "examples/hello.md"

--- a/src/examples/mod.rs
+++ b/src/examples/mod.rs
@@ -1,0 +1,107 @@
+use std::path::{Path, PathBuf};
+use serde::Deserialize;
+use rhai::{Dynamic, Engine};
+
+/// Metadata and execution support for a single Rhai example.
+#[derive(Clone, Debug)]
+pub struct Example {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub note: Option<String>,
+    pub doc_path: PathBuf,
+    pub script_path: PathBuf,
+}
+
+impl Example {
+    /// Run this example's script, returning the evaluation result or an error message.
+    pub fn run(&self) -> Dynamic {
+        let engine = Engine::new();
+        // Custom Rust types/functions could be registered on `engine` here.
+        match std::fs::read_to_string(&self.script_path) {
+            Ok(code) => engine
+                .eval::<Dynamic>(&code)
+                .unwrap_or_else(|e| format!("Error: {e}").into()),
+            Err(e) => format!("Error loading script: {e}").into(),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct Manifest {
+    examples: Vec<ManifestEntry>,
+}
+
+#[derive(Deserialize)]
+struct ManifestEntry {
+    id: String,
+    name: String,
+    script: String,
+    doc: String,
+}
+
+/// Registry of examples loaded from the manifest file.
+pub struct ExampleRegistry {
+    examples: Vec<Example>,
+}
+
+impl ExampleRegistry {
+    /// Load the example registry from `examples/manifest.toml`.
+    pub fn load() -> Self {
+        let manifest_path = Path::new("examples/manifest.toml");
+        let data = std::fs::read_to_string(manifest_path)
+            .expect("failed to read examples manifest");
+        let manifest: Manifest = toml::from_str(&data)
+            .expect("failed to parse examples manifest");
+
+        let examples = manifest
+            .examples
+            .into_iter()
+            .map(|m| {
+                let doc_path = PathBuf::from(&m.doc);
+                let script_path = PathBuf::from(&m.script);
+                let (description, note) = parse_doc(&doc_path);
+                Example {
+                    id: m.id,
+                    name: m.name,
+                    description,
+                    note,
+                    doc_path,
+                    script_path,
+                }
+            })
+            .collect();
+
+        Self { examples }
+    }
+}
+
+/// Parse a markdown document for description and optional note.
+fn parse_doc(path: &Path) -> (String, Option<String>) {
+    let text = std::fs::read_to_string(path).unwrap_or_default();
+    let mut description = String::new();
+    let mut note = None;
+
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if description.is_empty() {
+            description = line.to_string();
+        } else if line.to_lowercase().starts_with("note:") {
+            note = Some(line[5..].trim().to_string());
+            break;
+        }
+    }
+
+    (description, note)
+}
+
+/// Return all examples sorted by id.
+pub fn all() -> Vec<Example> {
+    let mut registry = ExampleRegistry::load();
+    registry.examples.sort_by(|a, b| a.id.cmp(&b.id));
+    registry.examples
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+mod examples;
+
 fn main() {
     println!("Hello, world!");
 }


### PR DESCRIPTION
## Summary
- create example registry that loads metadata from `examples/manifest.toml`
- implement `Example::run` helper to execute Rhai scripts
- parse markdown docs for description and note fields
- expose `examples::all` to list registered examples

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a1f5f4ea0c8332a8e5682fd967dc5a