### PR TITLE
Add project documentation and API comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ target
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# mdBook build output
+book/book

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
-# Rhai_Learning
-Rhai_Learning
+# Rhai Learning
+
+An interactive desktop application for experimenting with the
+[Rhai](https://rhai.rs) scripting language and the
+[egui](https://docs.rs/egui) GUI framework.  The project bundles a set of
+sample scripts and demonstrates how to embed a Rhai engine inside a Rust
+application.
+
+## Project Goals
+
+* Explore Rhai syntax and features through runnable examples.
+* Showcase integration patterns between Rhai and Rust/`egui`.
+* Provide a playground for testing script hot‑swapping and data exchange
+  techniques.
+
+## Setup
+
+1. Install [Rust](https://www.rust-lang.org/tools/install).
+2. Clone the repository and run the examples:
+
+   ```bash
+   cargo run
+   ```
+
+The application window lists all available example scripts located under
+[`examples/`](examples). Clicking **Run** executes the script and shows the
+result in the console panel. Each example links to its documentation and
+source so you can explore and modify the code.
+
+## UI Usage
+
+* **Example List** – displayed on the left. Select an entry to view details.
+* **Run** – executes the currently selected script.
+* **Reload scripts** – reloads example files from disk, making it easy to test
+  hot‑swapping.
+* **Logs panel** – if an example produces a log file under `logs/`, the
+  contents appear on the right.
+* **Console panel** – shows printed output and the evaluation result.
+
+Additional guides can be found in the [`docs/`](docs) directory or viewed as a
+compiled book using [mdBook](https://rust-lang.github.io/mdBook/).

--- a/book/book.toml
+++ b/book/book.toml
@@ -1,0 +1,6 @@
+[book]
+title = "Rhai Learning Guide"
+authors = ["Rhai Learning Contributors"]
+
+[build]
+build-dir = "book"

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,0 +1,7 @@
+# Summary
+
+- [Getting Started with Rhai](getting-started.md)
+- [Using Rust Types and External Crates from Rhai](rust-types-and-crates.md)
+- [Serialization and Data Exchange](serialization-data-exchange.md)
+- [Performance Considerations and Benchmarks](performance.md)
+- [Hot Swapping and Runtime Code Reloading](hot-swapping.md)

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -1,0 +1,1 @@
+{{#include ../../docs/getting-started.md}}

--- a/book/src/hot-swapping.md
+++ b/book/src/hot-swapping.md
@@ -1,0 +1,1 @@
+{{#include ../../docs/hot-swapping.md}}

--- a/book/src/performance.md
+++ b/book/src/performance.md
@@ -1,0 +1,1 @@
+{{#include ../../docs/performance.md}}

--- a/book/src/rust-types-and-crates.md
+++ b/book/src/rust-types-and-crates.md
@@ -1,0 +1,1 @@
+{{#include ../../docs/rust-types-and-crates.md}}

--- a/book/src/serialization-data-exchange.md
+++ b/book/src/serialization-data-exchange.md
@@ -1,0 +1,1 @@
+{{#include ../../docs/serialization-data-exchange.md}}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,29 @@
+# Getting Started with Rhai
+
+Rhai is a small and friendly scripting language for Rust. A script is a plain
+text file containing statements and expressions. Basic arithmetic and variable
+binding look like this:
+
+```rhai
+let x = 40 + 2;
+print(x);
+```
+
+You can run the above snippet in the app via the
+[basic arithmetic example](../examples/basic_arith.rhai). For a full tour of
+the language syntax see the [official Rhai book](https://rhai.rs/book/).
+
+### Integrating Rhai
+
+The simplest way to embed Rhai is to create an [`Engine`](https://docs.rs/rhai)
+and call `eval` on your script:
+
+```rust
+let engine = rhai::Engine::new();
+let result: i64 = engine.eval("1 + 2 + 3")?;
+```
+
+This project demonstrates a richer integration where the `Engine` is wired into
+an [`egui`](https://docs.rs/egui) user interface. Explore the rest of the docs
+for more advanced patterns.
+

--- a/docs/hot-swapping.md
+++ b/docs/hot-swapping.md
@@ -1,0 +1,13 @@
+# Hot Swapping and Runtime Code Reloading
+
+One of Rhai's strengths is the ability to reload scripts without restarting
+the host application. The [hot swap example](../examples/hot_swap.rhai) works
+with a text file and demonstrates updating logic while the UI stays running.
+
+The application exposes a **Reload scripts** button which refreshes the example
+manifest and any modified files. This allows rapid iteration on game logic or
+configuration scripts.
+
+More strategies for hot reloading are covered in the
+[Rhai book on dynamic modules](https://rhai.rs/book/engine/modules/dynamic.html).
+

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,16 @@
+# Performance Considerations and Benchmarks
+
+Rhai is designed to be lightweight, but there are a few tips to keep your
+scripts snappy:
+
+* Compile scripts once and reuse the [`AST`](https://rhai.rs/book/advanced/ast.html).
+* Avoid excessive dynamic allocations inside tight loops.
+* When calling Rust functions, prefer small `Copy` types over large `Struct`s.
+
+The [performance loop example](../examples/perf_loop.rhai) measures how quickly
+Rhai can execute a simple counted loop. Use it as a starting point for your own
+benchmarks.
+
+See the [Rhai performance guide](https://rhai.rs/book/performance/index.html)
+for more techniques and discussion.
+

--- a/docs/rust-types-and-crates.md
+++ b/docs/rust-types-and-crates.md
@@ -1,0 +1,21 @@
+# Using Rust Types and External Crates from Rhai
+
+Rhai can call functions and methods defined in Rust. To expose a custom type,
+register it with the scripting engine and provide constructor or method
+bindings. The [struct usage example](../examples/use_struct.rhai) showcases a
+`Point` type defined in Rust:
+
+```rust
+engine.register_type::<Point>();
+engine.register_fn("Point", Point::new);
+engine.register_fn("length", Point::length);
+```
+
+External crates can be wrapped in a similar fashion. The
+[HTTP request example](../examples/http_request.rhai) exposes a helper that
+uses the [`reqwest`](https://docs.rs/reqwest) crate to fetch JSON data over the
+network.
+
+For deeper integration techniques consult the
+[Rhai embedding guide](https://rhai.rs/book/engine/customize.html).
+

--- a/docs/serialization-data-exchange.md
+++ b/docs/serialization-data-exchange.md
@@ -1,0 +1,17 @@
+# Serialization and Data Exchange
+
+Scripts often need to talk to the outside world. Using
+[Serde](https://serde.rs/) together with Rhai's dynamic type system makes it
+easy to send and receive structured data. The
+[serialization example](../examples/serde_demo.rhai) demonstrates converting
+between Rhai `Dynamic` values and JSON strings:
+
+```rust
+engine.register_fn("to_json", to_json);
+engine.register_fn("from_json", from_json);
+```
+
+These helpers use `serde_json` under the hood to serialize/deserialize values.
+For a deeper discussion see the
+[Rhai book chapter on serialization](https://rhai.rs/book/engine/serialization.html).
+

--- a/src/examples/mod.rs
+++ b/src/examples/mod.rs
@@ -1,4 +1,6 @@
-use rhai::{module_resolvers::FileModuleResolver, Dynamic, Engine};
+//! Utilities for loading, running, and documenting Rhai example scripts.
+
+use rhai::{Dynamic, Engine, module_resolvers::FileModuleResolver};
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -50,17 +52,25 @@ fn read_file(path: &str) -> String {
 /// Metadata and execution support for a single Rhai example.
 #[derive(Clone, Debug)]
 pub struct Example {
+    /// Unique identifier for the example.
     pub id: String,
+    /// Human‑readable display name.
     pub name: String,
+    /// Short description shown in the UI.
     pub description: String,
+    /// Optional additional note.
     pub note: Option<String>,
+    /// Path to the Markdown documentation.
     pub doc_path: PathBuf,
+    /// Path to the Rhai script file.
     pub script_path: PathBuf,
 }
 
 /// Result of running a Rhai example.
 pub struct RunResult {
+    /// Captured standard output from the script.
     pub stdout: String,
+    /// Final value returned by the script.
     pub value: Dynamic,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+//! Entry point for the Rhai Learning application.
+
 mod examples;
 mod ui;
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1,3 +1,5 @@
+//! eframe/`egui` application displaying and executing Rhai examples.
+
 use crate::examples::{Example, ExampleRegistry};
 use eframe::egui;
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,1 +1,3 @@
+//! Graphical user interface components built with `egui`.
+
 pub mod app;


### PR DESCRIPTION
## Summary
- expand README with goals, setup, and UI guidance
- document examples and usage topics in `docs/` and `mdbook`
- add Rustdoc comments for public APIs

## Testing
- `cargo test`
- `cargo doc --no-deps`
- `mdbook build book`


------
https://chatgpt.com/codex/tasks/task_e_68a1fd96bc10833289495e2aa8168fb8