### PR TITLE
Add benchmark comparing Rust and Rhai implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,7 @@ reqwest = { version = "0.11", features = ["blocking", "json"] }
 
 [dev-dependencies]
 criterion = "0.7.0"
+
+[[bench]]
+name = "compare"
+harness = false

--- a/README.md
+++ b/README.md
@@ -39,3 +39,17 @@ source so you can explore and modify the code.
 
 Additional guides can be found in the [`docs/`](docs) directory or viewed as a
 compiled book using [mdBook](https://rust-lang.github.io/mdBook/).
+
+## Benchmarks
+
+The project includes Criterion benchmarks that compare equivalent logic
+implemented in pure Rust and in a Rhai script executed through the `Engine`.
+
+Run the benchmarks with:
+
+```bash
+cargo bench
+```
+
+Benchmark reports are written to `target/criterion/`, where you can review
+timing results and graphs for each benchmark.

--- a/benches/compare.rs
+++ b/benches/compare.rs
@@ -1,0 +1,23 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use rhai::{AST, Engine};
+
+const SCRIPT: &str = r#"let sum = 0; for n in 0..1000 { sum += n; } sum"#;
+
+fn pure_rust_sum() -> i64 {
+    (0..1000).sum()
+}
+
+fn rhai_sum(engine: &Engine, ast: &AST) -> i64 {
+    engine.eval_ast::<i64>(ast).expect("script evaluation")
+}
+
+fn benchmark(c: &mut Criterion) {
+    let engine = Engine::new();
+    let ast = engine.compile(SCRIPT).expect("compile script");
+
+    c.bench_function("pure_rust_sum", |b| b.iter(|| pure_rust_sum()));
+    c.bench_function("rhai_script_sum", |b| b.iter(|| rhai_sum(&engine, &ast)));
+}
+
+criterion_group!(benches, benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- add Criterion benchmark contrasting pure Rust sum with equivalent Rhai script
- document running benchmarks via `cargo bench`
- configure Criterion bench target

## Testing
- `cargo test`
- `cargo bench`


------
https://chatgpt.com/codex/tasks/task_e_68a200483b9c83329b8844e44bf21c16