### PR TITLE
Add custom module and async simulation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,21 @@ The application window lists all available example scripts located under
 result in the console panel. Each example links to its documentation and
 source so you can explore and modify the code.
 
+## Examples
+
+The project includes the following scripts:
+
+- Hello World
+- Basic Arithmetic
+- Using a Rust Struct
+- HTTP Request
+- Serde Demo
+- Performance Loop
+- Unit Test Style
+- Hot Swap
+- Custom Module – load functions from a user-defined module.
+- Async Simulation – mimic asynchronous tasks with a `sleep_ms` helper.
+
 ## UI Usage
 
 * **Example List** – displayed on the left. Select an entry to view details.

--- a/examples/async_sim.md
+++ b/examples/async_sim.md
@@ -1,0 +1,5 @@
+# Async Simulation
+
+Simulate an asynchronous delay using a helper function.
+
+Note: Uses `sleep_ms` registered from Rust to pause execution.

--- a/examples/async_sim.rhai
+++ b/examples/async_sim.rhai
@@ -1,0 +1,4 @@
+print("starting task...");
+sleep_ms(50);
+print("task complete");
+"done"

--- a/examples/custom_module.md
+++ b/examples/custom_module.md
@@ -1,0 +1,5 @@
+# Custom Module
+
+Load and use a user-defined Rhai module.
+
+This example imports `math_utils.rhai` and calls its `square` function.

--- a/examples/custom_module.rhai
+++ b/examples/custom_module.rhai
@@ -1,0 +1,6 @@
+import "math_utils.rhai" as math;
+
+let n = 4;
+let sq = math::square(n);
+print("square(" + n.to_string() + ") = " + sq.to_string());
+sq

--- a/examples/manifest.toml
+++ b/examples/manifest.toml
@@ -45,3 +45,15 @@ id = "hot-swap"
 name = "Hot Swap"
 script = "examples/hot_swap.rhai"
 doc = "examples/hot_swap.md"
+
+[[examples]]
+id = "custom-module"
+name = "Custom Module"
+script = "examples/custom_module.rhai"
+doc = "examples/custom_module.md"
+
+[[examples]]
+id = "async-sim"
+name = "Async Simulation"
+script = "examples/async_sim.rhai"
+doc = "examples/async_sim.md"

--- a/examples/math_utils.rhai
+++ b/examples/math_utils.rhai
@@ -1,0 +1,1 @@
+fn square(x) { x * x }

--- a/src/examples/mod.rs
+++ b/src/examples/mod.rs
@@ -49,6 +49,10 @@ fn read_file(path: &str) -> String {
     std::fs::read_to_string(path).unwrap_or_else(|e| format!("Error reading file: {e}"))
 }
 
+fn sleep_ms(ms: i64) {
+    std::thread::sleep(std::time::Duration::from_millis(ms as u64));
+}
+
 /// Metadata and execution support for a single Rhai example.
 #[derive(Clone, Debug)]
 pub struct Example {
@@ -112,6 +116,7 @@ impl Example {
         engine.register_fn("from_json", from_json);
         engine.register_fn("assert", assert_fn);
         engine.register_fn("read_file", read_file);
+        engine.register_fn("sleep_ms", sleep_ms);
 
         // Evaluate the script file so relative imports work.
         let value = engine
@@ -224,6 +229,8 @@ mod tests {
             "perf-loop",
             "unit-tests",
             "hot-swap",
+            "custom-module",
+            "async-sim",
         ];
 
         let registry = ExampleRegistry::all();

--- a/tests/rhai_examples.rs
+++ b/tests/rhai_examples.rs
@@ -3,7 +3,10 @@ use Rhai_Learning::examples::ExampleRegistry;
 #[test]
 fn hello_example_runs() {
     let registry = ExampleRegistry::all();
-    let ex = registry.iter().find(|e| e.id == "hello").expect("hello example");
+    let ex = registry
+        .iter()
+        .find(|e| e.id == "hello")
+        .expect("hello example");
     let result = ex.run();
     assert_eq!(result.stdout, "");
     assert_eq!(result.value.clone_cast::<String>(), "hello from rhai");
@@ -12,11 +15,38 @@ fn hello_example_runs() {
 #[test]
 fn unit_test_example_logs() {
     let registry = ExampleRegistry::all();
-    let ex = registry.iter().find(|e| e.id == "unit-tests").expect("unit-tests example");
+    let ex = registry
+        .iter()
+        .find(|e| e.id == "unit-tests")
+        .expect("unit-tests example");
     let result = ex.run();
     let expected = "DEBUG: \"starting tests\"\nDEBUG: \"math ok\"\nx=2\n";
     assert_eq!(result.stdout, expected);
     assert_eq!(result.value.as_bool().unwrap(), true);
     let log = std::fs::read_to_string("logs/unit-tests.log").expect("log file");
     assert_eq!(log, expected);
+}
+
+#[test]
+fn custom_module_example_runs() {
+    let registry = ExampleRegistry::all();
+    let ex = registry
+        .iter()
+        .find(|e| e.id == "custom-module")
+        .expect("custom-module example");
+    let result = ex.run();
+    assert!(result.stdout.contains("square(4) = 16"));
+    assert_eq!(result.value.clone_cast::<i64>(), 16);
+}
+
+#[test]
+fn async_sim_example_runs() {
+    let registry = ExampleRegistry::all();
+    let ex = registry
+        .iter()
+        .find(|e| e.id == "async-sim")
+        .expect("async-sim example");
+    let result = ex.run();
+    assert!(result.stdout.contains("task complete"));
+    assert_eq!(result.value.clone_cast::<String>(), "done");
 }


### PR DESCRIPTION
## Summary
- showcase importing a user-defined Rhai module
- demonstrate asynchronous delay with a `sleep_ms` helper
- document new examples and list them in README

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a20630cf0883329cccef3d3597f727