### PR TITLE
docs: expand example guides

### DIFF
--- a/examples/async_sim.md
+++ b/examples/async_sim.md
@@ -1,5 +1,32 @@
 # Async Simulation
 
-Simulate an asynchronous delay using a helper function.
+Simulates a short delay by pausing execution.
 
-Note: Uses `sleep_ms` registered from Rust to pause execution.
+## Code
+
+```rhai
+print("starting task...");
+sleep_ms(50);
+print("task complete");
+"done"
+```
+
+## How It Works
+
+`sleep_ms` is a Rust helper that blocks the current thread for the given
+milliseconds. The script prints messages before and after the pause and
+returns "done".
+
+Expected console output:
+
+```
+starting task...
+task complete
+```
+
+## Key Points
+
+- Uses the Rust function `sleep_ms` registered in `src/examples/mod.rs`.
+- Demonstrates sequencing of work around delays.
+
+Note: This helper merely sleeps the thread; it is not asynchronous. See <https://rhai.rs/book/operations/sleep.html>.

--- a/examples/basic_arith.md
+++ b/examples/basic_arith.md
@@ -1,3 +1,36 @@
 # Basic Arithmetic and Control Flow
 
-Demonstrates looping and conditionals in Rhai. See the [Rhai Book](https://rhai.rs/book/control-flow.html) for details.
+Adds numbers from 1 to 10 and reports the sum.
+
+## Code
+
+```rhai
+let sum = 0;
+for n in 1..=10 {
+    sum += n;
+}
+if sum > 50 {
+    print(`sum is ${sum}`);
+} else {
+    print("sum too small");
+}
+sum
+```
+
+## How It Works
+
+The loop accumulates the numbers 1 through 10. A conditional prints whether
+the total exceeds 50. The final expression evaluates to the sum.
+
+Expected console output:
+
+```
+sum is 55
+```
+
+## Key Points
+
+- Demonstrates `for` loops and `if` statements.
+- Returns the computed `sum`.
+
+Note: See <https://rhai.rs/book/control-flow.html> for more on Rhai control structures.

--- a/examples/collections.md
+++ b/examples/collections.md
@@ -1,6 +1,8 @@
 # Collections & Iteration
 
-Demonstrates creating arrays and maps, iterating over them, and mutating values.
+Mutates an array and a map before computing a total.
+
+## Code
 
 ```rhai
 let numbers = [1, 2, 3];
@@ -15,6 +17,23 @@ let scores = #{ "Alice": 1, "Bob": 2 };
 for name in scores.keys() {
     scores[name] += 1;
 }
+scores["Cara"] = total;
+numbers.push(scores["Bob"]);
+
+total
 ```
 
-The final value `total` is returned, showing the result of these mutations.
+## How It Works
+
+The script doubles each element of `numbers`, sums the results into `total`,
+and updates a `scores` map. The last expression yields the total sum.
+
+Expected console output: *(none)*
+
+## Key Points
+
+- Shows array indexing, iteration and mutation.
+- Demonstrates map operations and dynamic key access.
+- Returns the final `total` (12).
+
+Note: Collections in Rhai are dynamically typed; see <https://rhai.rs/book/language/arrays-maps.html>.

--- a/examples/custom_module.md
+++ b/examples/custom_module.md
@@ -1,5 +1,33 @@
 # Custom Module
 
-Load and use a user-defined Rhai module.
+Loads a user-defined module and calls its function.
 
-This example imports `math_utils.rhai` and calls its `square` function.
+## Code
+
+```rhai
+import "math_utils.rhai" as math;
+
+let n = 4;
+let sq = math::square(n);
+print("square(" + n.to_string() + ") = " + sq.to_string());
+sq
+```
+
+## How It Works
+
+`import` brings in `math_utils.rhai` as `math`. The `square` function is
+called to compute `n * n`, the result is printed, and the value `sq` is
+returned.
+
+Expected console output:
+
+```
+square(4) = 16
+```
+
+## Key Points
+
+- Demonstrates module loading with `import`.
+- No Rust helpers are used.
+
+Note: Module paths are relative to the script; see <https://rhai.rs/book/modules/import.html>.

--- a/examples/error_handling.md
+++ b/examples/error_handling.md
@@ -1,6 +1,8 @@
 # Error Handling
 
-Shows how to use `try`/`catch` and `throw` for custom error messages.
+Shows using `throw` with `try`/`catch`.
+
+## Code
 
 ```rhai
 fn divide(x, y) {
@@ -19,5 +21,25 @@ try {
     value = -1;
 }
 print("Caught: " + message);
+
+#{ msg: message, value: value }
 ```
-Running this prints `Caught: division by zero` and returns a map `{ msg: "division by zero", value: -1 }`.
+
+## How It Works
+
+`divide` throws an error when dividing by zero. The `try` block catches the
+error, records the message, and sets a fallback value. The script prints the
+captured message and returns it together with the value in a map.
+
+Expected console output:
+
+```
+Caught: division by zero
+```
+
+## Key Points
+
+- Illustrates `throw`, `try`, and `catch`.
+- Returns a map with the error message and computed value.
+
+Note: Error strings can be any `Dynamic`; see <https://rhai.rs/book/control-flow/error.html>.

--- a/examples/hello.md
+++ b/examples/hello.md
@@ -1,5 +1,21 @@
 # Hello World
 
-This example demonstrates running a simple Rhai script.
+Returns a simple greeting.
 
-Note: Prints a friendly greeting.
+## Code
+
+```rhai
+"hello from rhai"
+```
+
+## How It Works
+
+The script evaluates to a string. No output is printed; the returned value is
+the greeting.
+
+Expected console output: *(none)*
+
+## Key Points
+
+- Minimal example that returns a value.
+- Useful for verifying a basic Rhai setup.

--- a/examples/hot_swap.md
+++ b/examples/hot_swap.md
@@ -1,3 +1,30 @@
 # Hot Swap
 
-Reads a message from `hot_message.txt`. Editing the file and re-running changes the output, simulating hot-swapping. See [module loading](https://rhai.rs/book/modules/import.html).
+Reads a message from an external file.
+
+## Code
+
+```rhai
+let msg = read_file("examples/hot_message.txt");
+print(msg);
+msg
+```
+
+## How It Works
+
+`read_file` is a Rust helper that loads the text from `hot_message.txt`. The
+value is printed and then returned. Editing the file and rerunning the script
+changes the output.
+
+Expected console output:
+
+```
+Initial message
+```
+
+## Key Points
+
+- Demonstrates using the `read_file` helper to read disk files.
+- Mimics hot-swapping by reloading external content.
+
+Note: `read_file` reads relative to the process working directory.

--- a/examples/http_request.md
+++ b/examples/http_request.md
@@ -1,3 +1,35 @@
 # HTTP Request
 
-Calls an HTTP API using a `reqwest` helper registered with the engine. See [Rhai external functions](https://rhai.rs/book/rust/functions.html) and [reqwest](https://docs.rs/reqwest).
+Fetches JSON from a remote API.
+
+## Code
+
+```rhai
+let data = http_get("https://httpbin.org/get");
+if type_of(data) == "map" {
+    print(data.url);
+    data.url
+} else {
+    print(data);
+    data
+}
+```
+
+## How It Works
+
+`http_get` is a Rust helper using `reqwest` to perform a blocking HTTP GET and
+deserialize the JSON response into a Rhai `map`. The script prints the `url`
+field when successful; otherwise it prints an error string.
+
+Expected console output:
+
+```
+https://httpbin.org/get
+```
+
+## Key Points
+
+- Uses the `http_get` helper registered in `src/examples/mod.rs`.
+- Demonstrates type checking with `type_of`.
+
+Note: Network requests require the `reqwest` crate and internet access; see <https://rhai.rs/book/engine/https.html>.

--- a/examples/perf_loop.md
+++ b/examples/perf_loop.md
@@ -1,3 +1,32 @@
 # Performance Loop
 
-A tight loop performing 100k iterations to benchmark execution speed. See [Rhai benchmarking](https://rhai.rs/book/performance/benchmarking.html).
+Benchmarks a simple summation loop.
+
+## Code
+
+```rhai
+let total = 0;
+for n in 0..100000 {
+    total += n;
+}
+print(total);
+total
+```
+
+## How It Works
+
+The loop adds integers from 0 to 99,999, prints the sum, and returns it. This
+shows the cost of a tight loop in Rhai.
+
+Expected console output:
+
+```
+4999950000
+```
+
+## Key Points
+
+- Highlights looping performance.
+- No Rust helpers are used; everything runs in Rhai.
+
+Note: Use release builds for accurate benchmarks; see <https://rhai.rs/book/performance/benchmarking.html>.

--- a/examples/random.md
+++ b/examples/random.md
@@ -1,10 +1,25 @@
 # Random Number
 
-Uses the Rust helper `rand_int` (registered in the host application) to roll a six-sided die.
+Rolls a six-sided die using a host function.
+
+## Code
 
 ```rhai
 let roll = rand_int(1, 6);
 print(roll);
+roll
 ```
 
-The number printed and returned will be between `1` and `6`.
+## How It Works
+
+`rand_int` is a Rust helper returning a random integer in the given range
+(inclusive). The script prints the roll and returns it.
+
+Expected console output: a number between `1` and `6`.
+
+## Key Points
+
+- Demonstrates calling host functions from Rhai.
+- Results are nondeterministic.
+
+Note: `rand_int` uses the host RNG; results cannot be reproduced without seeding.

--- a/examples/serde_demo.md
+++ b/examples/serde_demo.md
@@ -1,3 +1,34 @@
 # Serde Demo
 
-Serializes and deserializes Rhai values through `serde` and `serde_json`. See [Rhai serde support](https://rhai.rs/book/features/serde.html).
+Serializes and deserializes values with JSON.
+
+## Code
+
+```rhai
+let data = #{ name: "Alice", age: 30 };
+let json = to_json(data);
+print(json);
+let parsed = from_json(json);
+print(`${parsed.name} is ${parsed.age} years old`);
+parsed
+```
+
+## How It Works
+
+`to_json` and `from_json` are Rust helpers backed by `serde_json`. The map is
+serialized to a JSON string, printed, parsed back, and printed again. The
+deserialized map is returned.
+
+Expected console output:
+
+```
+{"name":"Alice","age":30}
+Alice is 30 years old
+```
+
+## Key Points
+
+- Shows round-tripping data between Rhai and JSON.
+- Uses the `serde` feature via `to_json`/`from_json`.
+
+Note: Requires enabling `serde` support in the host application; see <https://rhai.rs/book/features/serde.html>.

--- a/examples/unit_tests.md
+++ b/examples/unit_tests.md
@@ -1,3 +1,35 @@
 # Unit Test Style
 
-Uses `debug` and `assert` macros to emulate unit tests in Rhai. See [testing scripts](https://rhai.rs/book/appendix/debugging.html).
+Mimics unit testing with debug logs and assertions.
+
+## Code
+
+```rhai
+debug("starting tests");
+let x = 1 + 1;
+assert(x == 2);
+debug("math ok");
+print(`x=${x}`);
+true
+```
+
+## How It Works
+
+`debug` writes diagnostic messages, while the Rust helper `assert` panics if
+its condition is false. The script prints the final value of `x` and returns
+`true` when all assertions pass.
+
+Expected console output:
+
+```
+DEBUG: starting tests
+DEBUG: math ok
+x=2
+```
+
+## Key Points
+
+- Combines `debug` and `assert` for lightweight test scripts.
+- `assert` is registered in `src/examples/mod.rs`.
+
+Note: The `debug` statements are captured by the host; see <https://rhai.rs/book/appendix/debugging.html>.

--- a/examples/use_struct.md
+++ b/examples/use_struct.md
@@ -1,3 +1,29 @@
 # Using a Rust Struct
 
-Shows how a Rust `Point` type and method registered on the `Engine` can be used from a Rhai script. See [embedding Rust types](https://rhai.rs/book/rust/types.html).
+Calls methods on a `Point` type defined in Rust.
+
+## Code
+
+```rhai
+let p = Point(3, 4);
+print(`length: ${p.length()}`);
+p.length()
+```
+
+## How It Works
+
+The `Point` struct and its `length` method are registered from Rust. The script
+constructs a point, prints its length, and returns the numeric result.
+
+Expected console output:
+
+```
+length: 5
+```
+
+## Key Points
+
+- Demonstrates binding a Rust type into Rhai.
+- Uses `Point` and `length` registered in `src/examples/mod.rs`.
+
+Note: Struct methods mutate `self` by default unless declared otherwise.


### PR DESCRIPTION
## Summary
- add structured documentation for all examples with code snippets, explanations, and key points
- describe Rust helper functions like `sleep_ms`, `http_get`, and registered types
- note expected console output and relevant Rhai docs links

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a2121c33448332acdcc5fc10ed6bd9