### PR TITLE
Generate HTML versions of example markdown files

### DIFF
--- a/examples/async_sim.html
+++ b/examples/async_sim.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+<h1>Async Simulation</h1>
+<p>Simulates a short delay by pausing execution.</p>
+<h2>Code</h2>
+<pre style="background-color:#2b303b;"><code class="language-rhai"><span style="color:#c0c5ce;">print(&quot;starting task...&quot;);
+</span><span style="color:#c0c5ce;">sleep_ms(50);
+</span><span style="color:#c0c5ce;">print(&quot;task complete&quot;);
+</span><span style="color:#c0c5ce;">&quot;done&quot;
+</span></code></pre>
+<h2>How It Works</h2>
+<p><code>sleep_ms</code> is a Rust helper that blocks the current thread for the given
+milliseconds. The script prints messages before and after the pause and
+returns &quot;done&quot;.</p>
+<p>Expected console output:</p>
+<pre style="background-color:#2b303b;"><code><span style="color:#c0c5ce;">starting task...
+</span><span style="color:#c0c5ce;">task complete
+</span></code></pre>
+<h2>Key Points</h2>
+<ul>
+<li>Uses the Rust function <code>sleep_ms</code> registered in <code>src/examples/mod.rs</code>.</li>
+<li>Demonstrates sequencing of work around delays.</li>
+</ul>
+<p>Note: This helper merely sleeps the thread; it is not asynchronous. See <a href="https://rhai.rs/book/operations/sleep.html">https://rhai.rs/book/operations/sleep.html</a>.</p>
+</body></html>

--- a/examples/basic_arith.html
+++ b/examples/basic_arith.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+<h1>Basic Arithmetic and Control Flow</h1>
+<p>Adds numbers from 1 to 10 and reports the sum.</p>
+<h2>Code</h2>
+<pre style="background-color:#2b303b;"><code class="language-rhai"><span style="color:#c0c5ce;">let sum = 0;
+</span><span style="color:#c0c5ce;">for n in 1..=10 {
+</span><span style="color:#c0c5ce;">    sum += n;
+</span><span style="color:#c0c5ce;">}
+</span><span style="color:#c0c5ce;">if sum &gt; 50 {
+</span><span style="color:#c0c5ce;">    print(`sum is ${sum}`);
+</span><span style="color:#c0c5ce;">} else {
+</span><span style="color:#c0c5ce;">    print(&quot;sum too small&quot;);
+</span><span style="color:#c0c5ce;">}
+</span><span style="color:#c0c5ce;">sum
+</span></code></pre>
+<h2>How It Works</h2>
+<p>The loop accumulates the numbers 1 through 10. A conditional prints whether
+the total exceeds 50. The final expression evaluates to the sum.</p>
+<p>Expected console output:</p>
+<pre style="background-color:#2b303b;"><code><span style="color:#c0c5ce;">sum is 55
+</span></code></pre>
+<h2>Key Points</h2>
+<ul>
+<li>Demonstrates <code>for</code> loops and <code>if</code> statements.</li>
+<li>Returns the computed <code>sum</code>.</li>
+</ul>
+<p>Note: See <a href="https://rhai.rs/book/control-flow.html">https://rhai.rs/book/control-flow.html</a> for more on Rhai control structures.</p>
+</body></html>

--- a/examples/collections.html
+++ b/examples/collections.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+<h1>Collections &amp; Iteration</h1>
+<p>Mutates an array and a map before computing a total.</p>
+<h2>Code</h2>
+<pre style="background-color:#2b303b;"><code class="language-rhai"><span style="color:#c0c5ce;">let numbers = [1, 2, 3];
+</span><span style="color:#c0c5ce;">for i in 0..numbers.len() {
+</span><span style="color:#c0c5ce;">    numbers[i] *= 2;
+</span><span style="color:#c0c5ce;">}
+</span><span style="color:#c0c5ce;">let total = 0;
+</span><span style="color:#c0c5ce;">for n in numbers {
+</span><span style="color:#c0c5ce;">    total += n;
+</span><span style="color:#c0c5ce;">}
+</span><span style="color:#c0c5ce;">let scores = #{ &quot;Alice&quot;: 1, &quot;Bob&quot;: 2 };
+</span><span style="color:#c0c5ce;">for name in scores.keys() {
+</span><span style="color:#c0c5ce;">    scores[name] += 1;
+</span><span style="color:#c0c5ce;">}
+</span><span style="color:#c0c5ce;">scores[&quot;Cara&quot;] = total;
+</span><span style="color:#c0c5ce;">numbers.push(scores[&quot;Bob&quot;]);
+</span><span style="color:#c0c5ce;">
+</span><span style="color:#c0c5ce;">total
+</span></code></pre>
+<h2>How It Works</h2>
+<p>The script doubles each element of <code>numbers</code>, sums the results into <code>total</code>,
+and updates a <code>scores</code> map. The last expression yields the total sum.</p>
+<p>Expected console output: <em>(none)</em></p>
+<h2>Key Points</h2>
+<ul>
+<li>Shows array indexing, iteration and mutation.</li>
+<li>Demonstrates map operations and dynamic key access.</li>
+<li>Returns the final <code>total</code> (12).</li>
+</ul>
+<p>Note: Collections in Rhai are dynamically typed; see <a href="https://rhai.rs/book/language/arrays-maps.html">https://rhai.rs/book/language/arrays-maps.html</a>.</p>
+</body></html>

--- a/examples/custom_module.html
+++ b/examples/custom_module.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+<h1>Custom Module</h1>
+<p>Loads a user-defined module and calls its function.</p>
+<h2>Code</h2>
+<pre style="background-color:#2b303b;"><code class="language-rhai"><span style="color:#c0c5ce;">import &quot;math_utils.rhai&quot; as math;
+</span><span style="color:#c0c5ce;">
+</span><span style="color:#c0c5ce;">let n = 4;
+</span><span style="color:#c0c5ce;">let sq = math::square(n);
+</span><span style="color:#c0c5ce;">print(&quot;square(&quot; + n.to_string() + &quot;) = &quot; + sq.to_string());
+</span><span style="color:#c0c5ce;">sq
+</span></code></pre>
+<h2>How It Works</h2>
+<p><code>import</code> brings in <code>math_utils.rhai</code> as <code>math</code>. The <code>square</code> function is
+called to compute <code>n * n</code>, the result is printed, and the value <code>sq</code> is
+returned.</p>
+<p>Expected console output:</p>
+<pre style="background-color:#2b303b;"><code><span style="color:#c0c5ce;">square(4) = 16
+</span></code></pre>
+<h2>Key Points</h2>
+<ul>
+<li>Demonstrates module loading with <code>import</code>.</li>
+<li>No Rust helpers are used.</li>
+</ul>
+<p>Note: Module paths are relative to the script; see <a href="https://rhai.rs/book/modules/import.html">https://rhai.rs/book/modules/import.html</a>.</p>
+</body></html>

--- a/examples/error_handling.html
+++ b/examples/error_handling.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+<h1>Error Handling</h1>
+<p>Shows using <code>throw</code> with <code>try</code>/<code>catch</code>.</p>
+<h2>Code</h2>
+<pre style="background-color:#2b303b;"><code class="language-rhai"><span style="color:#c0c5ce;">fn divide(x, y) {
+</span><span style="color:#c0c5ce;">    if y == 0 {
+</span><span style="color:#c0c5ce;">        throw &quot;division by zero&quot;;
+</span><span style="color:#c0c5ce;">    }
+</span><span style="color:#c0c5ce;">    x / y
+</span><span style="color:#c0c5ce;">}
+</span><span style="color:#c0c5ce;">
+</span><span style="color:#c0c5ce;">let message = &quot;&quot;;
+</span><span style="color:#c0c5ce;">let value = 0;
+</span><span style="color:#c0c5ce;">try {
+</span><span style="color:#c0c5ce;">    value = divide(10, 0);
+</span><span style="color:#c0c5ce;">} catch (err) {
+</span><span style="color:#c0c5ce;">    message = err;
+</span><span style="color:#c0c5ce;">    value = -1;
+</span><span style="color:#c0c5ce;">}
+</span><span style="color:#c0c5ce;">print(&quot;Caught: &quot; + message);
+</span><span style="color:#c0c5ce;">
+</span><span style="color:#c0c5ce;">#{ msg: message, value: value }
+</span></code></pre>
+<h2>How It Works</h2>
+<p><code>divide</code> throws an error when dividing by zero. The <code>try</code> block catches the
+error, records the message, and sets a fallback value. The script prints the
+captured message and returns it together with the value in a map.</p>
+<p>Expected console output:</p>
+<pre style="background-color:#2b303b;"><code><span style="color:#c0c5ce;">Caught: division by zero
+</span></code></pre>
+<h2>Key Points</h2>
+<ul>
+<li>Illustrates <code>throw</code>, <code>try</code>, and <code>catch</code>.</li>
+<li>Returns a map with the error message and computed value.</li>
+</ul>
+<p>Note: Error strings can be any <code>Dynamic</code>; see <a href="https://rhai.rs/book/control-flow/error.html">https://rhai.rs/book/control-flow/error.html</a>.</p>
+</body></html>

--- a/examples/hello.html
+++ b/examples/hello.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+<h1>Hello World</h1>
+<p>Returns a simple greeting.</p>
+<h2>Code</h2>
+<pre style="background-color:#2b303b;"><code class="language-rhai"><span style="color:#c0c5ce;">&quot;hello from rhai&quot;
+</span></code></pre>
+<h2>How It Works</h2>
+<p>The script evaluates to a string. No output is printed; the returned value is
+the greeting.</p>
+<p>Expected console output: <em>(none)</em></p>
+<h2>Key Points</h2>
+<ul>
+<li>Minimal example that returns a value.</li>
+<li>Useful for verifying a basic Rhai setup.</li>
+</ul>
+</body></html>

--- a/examples/hot_swap.html
+++ b/examples/hot_swap.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+<h1>Hot Swap</h1>
+<p>Reads a message from an external file.</p>
+<h2>Code</h2>
+<pre style="background-color:#2b303b;"><code class="language-rhai"><span style="color:#c0c5ce;">let msg = read_file(&quot;examples/hot_message.txt&quot;);
+</span><span style="color:#c0c5ce;">print(msg);
+</span><span style="color:#c0c5ce;">msg
+</span></code></pre>
+<h2>How It Works</h2>
+<p><code>read_file</code> is a Rust helper that loads the text from <code>hot_message.txt</code>. The
+value is printed and then returned. Editing the file and rerunning the script
+changes the output.</p>
+<p>Expected console output:</p>
+<pre style="background-color:#2b303b;"><code><span style="color:#c0c5ce;">Initial message
+</span></code></pre>
+<h2>Key Points</h2>
+<ul>
+<li>Demonstrates using the <code>read_file</code> helper to read disk files.</li>
+<li>Mimics hot-swapping by reloading external content.</li>
+</ul>
+<p>Note: <code>read_file</code> reads relative to the process working directory.</p>
+</body></html>

--- a/examples/http_request.html
+++ b/examples/http_request.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+<h1>HTTP Request</h1>
+<p>Fetches JSON from a remote API.</p>
+<h2>Code</h2>
+<pre style="background-color:#2b303b;"><code class="language-rhai"><span style="color:#c0c5ce;">let data = http_get(&quot;https://httpbin.org/get&quot;);
+</span><span style="color:#c0c5ce;">if type_of(data) == &quot;map&quot; {
+</span><span style="color:#c0c5ce;">    print(data.url);
+</span><span style="color:#c0c5ce;">    data.url
+</span><span style="color:#c0c5ce;">} else {
+</span><span style="color:#c0c5ce;">    print(data);
+</span><span style="color:#c0c5ce;">    data
+</span><span style="color:#c0c5ce;">}
+</span></code></pre>
+<h2>How It Works</h2>
+<p><code>http_get</code> is a Rust helper using <code>reqwest</code> to perform a blocking HTTP GET and
+deserialize the JSON response into a Rhai <code>map</code>. The script prints the <code>url</code>
+field when successful; otherwise it prints an error string.</p>
+<p>Expected console output:</p>
+<pre style="background-color:#2b303b;"><code><span style="color:#c0c5ce;">https://httpbin.org/get
+</span></code></pre>
+<h2>Key Points</h2>
+<ul>
+<li>Uses the <code>http_get</code> helper registered in <code>src/examples/mod.rs</code>.</li>
+<li>Demonstrates type checking with <code>type_of</code>.</li>
+</ul>
+<p>Note: Network requests require the <code>reqwest</code> crate and internet access; see <a href="https://rhai.rs/book/engine/https.html">https://rhai.rs/book/engine/https.html</a>.</p>
+</body></html>

--- a/examples/perf_loop.html
+++ b/examples/perf_loop.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+<h1>Performance Loop</h1>
+<p>Benchmarks a simple summation loop.</p>
+<h2>Code</h2>
+<pre style="background-color:#2b303b;"><code class="language-rhai"><span style="color:#c0c5ce;">let total = 0;
+</span><span style="color:#c0c5ce;">for n in 0..100000 {
+</span><span style="color:#c0c5ce;">    total += n;
+</span><span style="color:#c0c5ce;">}
+</span><span style="color:#c0c5ce;">print(total);
+</span><span style="color:#c0c5ce;">total
+</span></code></pre>
+<h2>How It Works</h2>
+<p>The loop adds integers from 0 to 99,999, prints the sum, and returns it. This
+shows the cost of a tight loop in Rhai.</p>
+<p>Expected console output:</p>
+<pre style="background-color:#2b303b;"><code><span style="color:#c0c5ce;">4999950000
+</span></code></pre>
+<h2>Key Points</h2>
+<ul>
+<li>Highlights looping performance.</li>
+<li>No Rust helpers are used; everything runs in Rhai.</li>
+</ul>
+<p>Note: Use release builds for accurate benchmarks; see <a href="https://rhai.rs/book/performance/benchmarking.html">https://rhai.rs/book/performance/benchmarking.html</a>.</p>
+</body></html>

--- a/examples/random.html
+++ b/examples/random.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+<h1>Random Number</h1>
+<p>Rolls a six-sided die using a host function.</p>
+<h2>Code</h2>
+<pre style="background-color:#2b303b;"><code class="language-rhai"><span style="color:#c0c5ce;">let roll = rand_int(1, 6);
+</span><span style="color:#c0c5ce;">print(roll);
+</span><span style="color:#c0c5ce;">roll
+</span></code></pre>
+<h2>How It Works</h2>
+<p><code>rand_int</code> is a Rust helper returning a random integer in the given range
+(inclusive). The script prints the roll and returns it.</p>
+<p>Expected console output: a number between <code>1</code> and <code>6</code>.</p>
+<h2>Key Points</h2>
+<ul>
+<li>Demonstrates calling host functions from Rhai.</li>
+<li>Results are nondeterministic.</li>
+</ul>
+<p>Note: <code>rand_int</code> uses the host RNG; results cannot be reproduced without seeding.</p>
+</body></html>

--- a/examples/serde_demo.html
+++ b/examples/serde_demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+<h1>Serde Demo</h1>
+<p>Serializes and deserializes values with JSON.</p>
+<h2>Code</h2>
+<pre style="background-color:#2b303b;"><code class="language-rhai"><span style="color:#c0c5ce;">let data = #{ name: &quot;Alice&quot;, age: 30 };
+</span><span style="color:#c0c5ce;">let json = to_json(data);
+</span><span style="color:#c0c5ce;">print(json);
+</span><span style="color:#c0c5ce;">let parsed = from_json(json);
+</span><span style="color:#c0c5ce;">print(`${parsed.name} is ${parsed.age} years old`);
+</span><span style="color:#c0c5ce;">parsed
+</span></code></pre>
+<h2>How It Works</h2>
+<p><code>to_json</code> and <code>from_json</code> are Rust helpers backed by <code>serde_json</code>. The map is
+serialized to a JSON string, printed, parsed back, and printed again. The
+deserialized map is returned.</p>
+<p>Expected console output:</p>
+<pre style="background-color:#2b303b;"><code><span style="color:#c0c5ce;">{&quot;name&quot;:&quot;Alice&quot;,&quot;age&quot;:30}
+</span><span style="color:#c0c5ce;">Alice is 30 years old
+</span></code></pre>
+<h2>Key Points</h2>
+<ul>
+<li>Shows round-tripping data between Rhai and JSON.</li>
+<li>Uses the <code>serde</code> feature via <code>to_json</code>/<code>from_json</code>.</li>
+</ul>
+<p>Note: Requires enabling <code>serde</code> support in the host application; see <a href="https://rhai.rs/book/features/serde.html">https://rhai.rs/book/features/serde.html</a>.</p>
+</body></html>

--- a/examples/unit_tests.html
+++ b/examples/unit_tests.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+<h1>Unit Test Style</h1>
+<p>Mimics unit testing with debug logs and assertions.</p>
+<h2>Code</h2>
+<pre style="background-color:#2b303b;"><code class="language-rhai"><span style="color:#c0c5ce;">debug(&quot;starting tests&quot;);
+</span><span style="color:#c0c5ce;">let x = 1 + 1;
+</span><span style="color:#c0c5ce;">assert(x == 2);
+</span><span style="color:#c0c5ce;">debug(&quot;math ok&quot;);
+</span><span style="color:#c0c5ce;">print(`x=${x}`);
+</span><span style="color:#c0c5ce;">true
+</span></code></pre>
+<h2>How It Works</h2>
+<p><code>debug</code> writes diagnostic messages, while the Rust helper <code>assert</code> panics if
+its condition is false. The script prints the final value of <code>x</code> and returns
+<code>true</code> when all assertions pass.</p>
+<p>Expected console output:</p>
+<pre style="background-color:#2b303b;"><code><span style="color:#c0c5ce;">DEBUG: starting tests
+</span><span style="color:#c0c5ce;">DEBUG: math ok
+</span><span style="color:#c0c5ce;">x=2
+</span></code></pre>
+<h2>Key Points</h2>
+<ul>
+<li>Combines <code>debug</code> and <code>assert</code> for lightweight test scripts.</li>
+<li><code>assert</code> is registered in <code>src/examples/mod.rs</code>.</li>
+</ul>
+<p>Note: The <code>debug</code> statements are captured by the host; see <a href="https://rhai.rs/book/appendix/debugging.html">https://rhai.rs/book/appendix/debugging.html</a>.</p>
+</body></html>

--- a/examples/use_struct.html
+++ b/examples/use_struct.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+<h1>Using a Rust Struct</h1>
+<p>Calls methods on a <code>Point</code> type defined in Rust.</p>
+<h2>Code</h2>
+<pre style="background-color:#2b303b;"><code class="language-rhai"><span style="color:#c0c5ce;">let p = Point(3, 4);
+</span><span style="color:#c0c5ce;">print(`length: ${p.length()}`);
+</span><span style="color:#c0c5ce;">p.length()
+</span></code></pre>
+<h2>How It Works</h2>
+<p>The <code>Point</code> struct and its <code>length</code> method are registered from Rust. The script
+constructs a point, prints its length, and returns the numeric result.</p>
+<p>Expected console output:</p>
+<pre style="background-color:#2b303b;"><code><span style="color:#c0c5ce;">length: 5
+</span></code></pre>
+<h2>Key Points</h2>
+<ul>
+<li>Demonstrates binding a Rust type into Rhai.</li>
+<li>Uses <code>Point</code> and <code>length</code> registered in <code>src/examples/mod.rs</code>.</li>
+</ul>
+<p>Note: Struct methods mutate <code>self</code> by default unless declared otherwise.</p>
+</body></html>


### PR DESCRIPTION
## Summary
- convert each Markdown file in `examples/` to a static HTML page with basic boilerplate
- commit the generated `.html` files for direct use in the application

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a22173a2c883329c82f319de309ad4