### PR TITLE
Load example docs from HTML, parse descriptions from Markdown

### DIFF
--- a/src/examples/mod.rs
+++ b/src/examples/mod.rs
@@ -70,7 +70,10 @@ pub struct Example {
     /// Optional additional note.
     pub note: Option<String>,
     /// Path to the Markdown documentation.
+    #[allow(dead_code)]
     pub doc_path: PathBuf,
+    /// Path to the rendered HTML documentation.
+    pub doc_html_path: PathBuf,
     /// Path to the Rhai script file.
     pub script_path: PathBuf,
 }
@@ -172,7 +175,8 @@ impl ExampleRegistry {
             .examples
             .into_iter()
             .map(|m| {
-                let doc_path = PathBuf::from(&m.doc);
+                let doc_html_path = PathBuf::from(&m.doc);
+                let doc_path = doc_html_path.with_extension("md");
                 let script_path = PathBuf::from(&m.script);
                 let (description, note) = parse_doc(&doc_path);
                 Example {
@@ -181,6 +185,7 @@ impl ExampleRegistry {
                     description,
                     note,
                     doc_path,
+                    doc_html_path,
                     script_path,
                 }
             })

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -138,7 +138,7 @@ impl eframe::App for App {
                 if let Some(note) = &ex.note {
                     ui.label(format!("Note: {}", note));
                 }
-                ui.hyperlink_to("Documentation", ex.doc_path.to_string_lossy());
+                ui.hyperlink_to("Documentation", ex.doc_html_path.to_string_lossy());
                 if ui.button("Run").clicked() {
                     self.run_selected();
                 }


### PR DESCRIPTION
## Summary
- Store both rendered HTML and Markdown doc paths for examples
- Derive Markdown path from HTML manifest entry when loading examples
- Link UI documentation buttons to HTML while parsing text from Markdown

## Testing
- `cargo fmt`
- `cargo test`

 