### PR TITLE
Add test ensuring example docs exist

### DIFF
--- a/tests/rhai_examples.rs
+++ b/tests/rhai_examples.rs
@@ -1,6 +1,14 @@
 use Rhai_Learning::examples::ExampleRegistry;
 
 #[test]
+fn example_docs_exist() {
+    let registry = ExampleRegistry::all();
+    for ex in &registry {
+        assert!(ex.doc_html_path.exists(), "missing doc for {}", ex.id);
+    }
+}
+
+#[test]
 fn hello_example_runs() {
     let registry = ExampleRegistry::all();
     let ex = registry


### PR DESCRIPTION
## Summary
- verify each example has corresponding HTML documentation
- keep existing example tests intact

## Testing
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a22a47cb78833280cb5e0d61266fbb